### PR TITLE
add a new method to HasArguments

### DIFF
--- a/openmsitoolbox/argument_parsing/has_arguments.py
+++ b/openmsitoolbox/argument_parsing/has_arguments.py
@@ -4,6 +4,7 @@ also extends Runnable
 """
 
 # imports
+from argparse import Namespace
 from abc import ABC, abstractmethod
 from typing import List, Dict, Tuple, Any
 
@@ -30,7 +31,9 @@ class HasArguments(ABC):
 
     @classmethod
     @abstractmethod
-    def get_init_args_kwargs(cls, parsed_args) -> Tuple[List[str], Dict[str, Any]]:
+    def get_init_args_kwargs(
+        cls, parsed_args: Namespace
+    ) -> Tuple[List[str], Dict[str, Any]]:
         """Get the list of init arguments and the dictionary of init keyword arguments
         for this class given a namespace of, for example, parsed arguments.
 

--- a/openmsitoolbox/argument_parsing/has_arguments.py
+++ b/openmsitoolbox/argument_parsing/has_arguments.py
@@ -27,3 +27,18 @@ class HasArguments(ABC):
         :rtype: dict
         """
         return [], {}
+    
+    @classmethod
+    @abstractmethod
+    def get_init_args_kwargs(cls, parsed_args) -> Tuple[List[str], Dict[str, Any]]:
+        """Get the list of init arguments and the dictionary of init keyword arguments
+        for this class given a namespace of, for example, parsed arguments.
+        
+        :param parsed_args: A namespace containing entries needed to determine the init
+            args and kwargs for this class
+        :type parsed_args: argparse.Namespace
+
+        :return: A list of init args
+        :return: A dictionary of init kwargs
+        """
+        return [], {}

--- a/openmsitoolbox/argument_parsing/has_arguments.py
+++ b/openmsitoolbox/argument_parsing/has_arguments.py
@@ -27,13 +27,13 @@ class HasArguments(ABC):
         :rtype: dict
         """
         return [], {}
-    
+
     @classmethod
     @abstractmethod
     def get_init_args_kwargs(cls, parsed_args) -> Tuple[List[str], Dict[str, Any]]:
         """Get the list of init arguments and the dictionary of init keyword arguments
         for this class given a namespace of, for example, parsed arguments.
-        
+
         :param parsed_args: A namespace containing entries needed to determine the init
             args and kwargs for this class
         :type parsed_args: argparse.Namespace

--- a/openmsitoolbox/logging/log_owner.py
+++ b/openmsitoolbox/logging/log_owner.py
@@ -1,6 +1,7 @@
 " Anything that owns an OpenMSILogger "
 
 # imports
+from argparse import Namespace
 import logging
 import pathlib
 from typing import Any, Dict, List, Tuple
@@ -83,7 +84,20 @@ class LogOwner(HasArguments):
         args = [
             *superargs,
             "logger_stream_level",
-            "logger_file_level",
             "logger_file_path",
+            "logger_file_level",
         ]
         return args, superkwargs
+
+    @classmethod
+    def get_init_args_kwargs(
+        cls, parsed_args: Namespace
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        superargs, superkwargs = super().get_init_args_kwargs(parsed_args)
+        kwargs = {
+            **superkwargs,
+            "streamlevel": parsed_args.logger_stream_level,
+            "logger_file": parsed_args.logger_file_path,
+            "filelevel": parsed_args.logger_file_level,
+        }
+        return superargs, kwargs

--- a/openmsitoolbox/version.py
+++ b/openmsitoolbox/version.py
@@ -1,2 +1,2 @@
 "The software version property"
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
This PR adds a new class method to the HasArguments class that will return a class's init args and kwargs given a namespace of parsed command line arguments. This will make it easier to propagate command line options through when classes are initialized.