### PR TITLE
Fixup style and update version

### DIFF
--- a/openmsitoolbox/logging/openmsi_logger.py
+++ b/openmsitoolbox/logging/openmsi_logger.py
@@ -44,7 +44,7 @@ class OpenMSILogger:
         name = the name for this logger to use (probably something like the top module that owns it)
         """
         # set global logging level if requested. We use the lower number (more verbose) as default
-        self.level = min(streamlevel,filelevel)
+        self.level = min(streamlevel, filelevel)
         if conf_global_logger:
             # This line ensures a default level if logger hasnt yet been used
             logging.basicConfig(level=self.level)
@@ -64,11 +64,9 @@ class OpenMSILogger:
             self.add_file_handler(logger_filepath, level=filelevel)
         if conf_global_logger:
             # override warnings output via us
-            warnings.showwarning = \
-                lambda message, category, filename, lineno, f=None, line=None: \
-                self._logger_obj.warning(
-                    warnings.formatwarning(message, category, filename, lineno)
-                )
+            warnings.showwarning = lambda message, category, filename, lineno, f=None, line=None: self._logger_obj.warning(
+                warnings.formatwarning(message, category, filename, lineno)
+            )
 
     def set_level(self, level: int) -> None:
         """

--- a/openmsitoolbox/version.py
+++ b/openmsitoolbox/version.py
@@ -1,2 +1,2 @@
 "The software version property"
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/openmsitoolbox/version.py
+++ b/openmsitoolbox/version.py
@@ -1,2 +1,2 @@
 "The software version property"
-__version__ = "1.2.4"
+__version__ = "1.2.4post1"


### PR DESCRIPTION
Apparently version v1.2.4 was tagged without updating the code version number. Fix that, and to allow a new pushed version, use then a "post1" (see https://peps.python.org/pep-0440/ ) version.

Also includes two "black" style changes.

TLDR: merge this PR, tag the new version as "v1.2.4.post1", and then push a new version to PyPI (the tagged 1.2.4 was not pushed to PyPI, see https://pypi.org/project/openmsitoolbox/#history , no need to push 1.2.4, just push 1.2.4.post1 ).

Thank you!